### PR TITLE
fix: resolve operator ambiguity in i3 foreign key check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,45 +37,45 @@ jobs:
     
     - name: Install PostgreSQL client
       run: |
-        # Install default PostgreSQL client (works for all versions)
         sudo apt-get update
         sudo apt-get install -y postgresql-client
-        
-        # Verify installation
         psql --version
     
     - name: Prepare test database
       run: |
-        # Wait for PostgreSQL to be ready
         until pg_isready -h localhost -p 5432 -U postgres; do
           echo "Waiting for postgres..."
           sleep 2
         done
         
-        # Check PostgreSQL version
         psql -h localhost -U postgres -d test -c 'SELECT version();'
         
-        # Create extensions (pg_stat_statements may not work without shared_preload_libraries)
-        psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;' || echo "Warning: pg_stat_statements extension not available"
+        # Extensions
+        psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;' || echo "Warning: pg_stat_statements not available"
         psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pgstattuple;'
+        psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS intarray;'
         
-        # Create minimal privilege user for testing
+        # Minimal privilege user
         psql -h localhost -U postgres -d test -c "CREATE USER dba_user;"
         psql -h localhost -U postgres -d test -c "GRANT pg_monitor TO dba_user;"
         psql -h localhost -U postgres -d test -c "GRANT CONNECT ON DATABASE test TO dba_user;"
         psql -h localhost -U postgres -d test -c "GRANT USAGE ON SCHEMA public TO dba_user;"
         
-        # Verify extensions
         psql -h localhost -U postgres -d test -c 'SELECT extname FROM pg_extension ORDER BY extname;'
         
-        # Create test tables for alignment testing (as superuser)
+        # Test tables for alignment (p1)
         psql -h localhost -U postgres -d test -c "CREATE TABLE align1 AS SELECT 1::int4, 2::int8, 3::int4 AS more FROM generate_series(1, 100000) _(i);"
         psql -h localhost -U postgres -d test -c "CREATE TABLE align2 AS SELECT 1::int4, 3::int4 AS more, 2::int8 FROM generate_series(1, 100000) _(i);"
         
-        # Grant access to test tables for dba_user
-        psql -h localhost -U postgres -d test -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO dba_user;"
+        # Test tables for foreign key check (i3) — with intarray to catch operator ambiguity
+        psql -h localhost -U postgres -d test -c "CREATE TABLE fk_parent (id int PRIMARY KEY, data text);"
+        psql -h localhost -U postgres -d test -c "CREATE TABLE fk_child (id int PRIMARY KEY, parent_id int, data text, CONSTRAINT fk_test FOREIGN KEY (parent_id) REFERENCES fk_parent(id));"
+        psql -h localhost -U postgres -d test -c "INSERT INTO fk_parent SELECT i, 'data_' || i FROM generate_series(1, 100000) i;"
+        psql -h localhost -U postgres -d test -c "INSERT INTO fk_child SELECT i, (i % 100000) + 1, 'data_' || i FROM generate_series(1, 200000) i;"
+        psql -h localhost -U postgres -d test -c "ANALYZE;"
         
-        # Test connection as dba_user
+        # Grant access
+        psql -h localhost -U postgres -d test -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO dba_user;"
         psql -h localhost -U dba_user -d test -c 'SELECT current_user, session_user;'
     
     - name: Test wide mode
@@ -83,12 +83,12 @@ jobs:
         echo "\set postgres_dba_wide true" > ~/.psqlrc
         echo "\set postgres_dba_interactive_mode false" >> ~/.psqlrc
         echo "Testing all SQL files in wide mode with minimal privileges..."
-        for f in sql/*; do 
+        for f in sql/*; do
           echo "  Testing $f..."
-          if ! psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f" > /dev/null 2>&1; then
+          if ! PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f" > /dev/null 2>&1; then
             echo "❌ FAILED: $f in wide mode"
             echo "Error output:"
-            psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f"
+            PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f"
             exit 1
           fi
         done
@@ -99,12 +99,12 @@ jobs:
         echo "\set postgres_dba_wide false" > ~/.psqlrc
         echo "\set postgres_dba_interactive_mode false" >> ~/.psqlrc
         echo "Testing all SQL files in normal mode with minimal privileges..."
-        for f in sql/*; do 
+        for f in sql/*; do
           echo "  Testing $f..."
-          if ! psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f" > /dev/null 2>&1; then
+          if ! PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f" > /dev/null 2>&1; then
             echo "❌ FAILED: $f in normal mode"
             echo "Error output:"
-            psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f"
+            PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f "$f"
             exit 1
           fi
         done
@@ -118,7 +118,7 @@ jobs:
         echo "Running regression tests with minimal privileges..."
         
         echo "  Testing 0_node.sql..."
-        OUTPUT=$(psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/0_node.sql | grep Role)
+        OUTPUT=$(PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/0_node.sql | grep Role)
         if [[ "$OUTPUT" == *"Master"* ]]; then
           echo "    ✓ Role test passed"
         else
@@ -127,7 +127,7 @@ jobs:
         fi
         
         echo "  Testing p1_alignment_padding.sql..."
-        OUTPUT=$(psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/p1_alignment_padding.sql | grep align)
+        OUTPUT=$(PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/p1_alignment_padding.sql | grep align)
         if [[ "$OUTPUT" == *"align1"* && "$OUTPUT" == *"align2"* && "$OUTPUT" == *"int4, more, int8"* ]]; then
           echo "    ✓ Alignment padding test passed"
         else
@@ -136,7 +136,7 @@ jobs:
         fi
         
         echo "  Testing a1_activity.sql..."
-        OUTPUT=$(psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/a1_activity.sql | grep User)
+        OUTPUT=$(PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/a1_activity.sql | grep User)
         if [[ "$OUTPUT" == *"User"* ]]; then
           echo "    ✓ Activity test passed"
         else
@@ -144,6 +144,18 @@ jobs:
           exit 1
         fi
         
+        echo "  Testing i3_non_indexed_fks.sql (with intarray extension)..."
+        OUTPUT=$(PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/i3_non_indexed_fks.sql 2>&1)
+        if [[ "$OUTPUT" == *"ERROR"* ]]; then
+          echo "    ✗ i3 test failed with error:"
+          echo "$OUTPUT"
+          exit 1
+        elif [[ "$OUTPUT" == *"fk_child"* && "$OUTPUT" == *"fk_test"* ]]; then
+          echo "    ✓ i3 foreign key test passed (found missing index on FK)"
+        else
+          echo "    ✗ i3 test failed: unexpected output"
+          echo "$OUTPUT"
+          exit 1
+        fi
+        
         echo "✅ All regression tests passed with minimal privileges"
-
-

--- a/sql/i3_non_indexed_fks.sql
+++ b/sql/i3_non_indexed_fks.sql
@@ -63,7 +63,7 @@ with fk_actions ( code, action ) as (
   join fk_cols_list using (fkoid)
   left join index_list on
     conrelid = indrelid
-    and (indkey::int2[])[0:(array_length(key_cols,1) -1)] operator(pg_catalog.@>) key_cols
+    and (indkey::int2[])[0:(array_length(key_cols,1) -1)] operator(pg_catalog.@>) key_cols::int2[]
 
 ), fk_perfect_match as (
   select fkoid


### PR DESCRIPTION
## Summary

Rebased version of #72 — fixes the `operator is not unique` error in i3 when intarray extension is installed.

### SQL fix
Added explicit `::int2[]` cast to `key_cols` parameter so PostgreSQL unambiguously resolves the `@>` operator.

### CI improvements
- Install `intarray` extension in test matrix (reproduces the ambiguity environment)
- Add FK test tables (`fk_parent`/`fk_child`) for i3 regression testing
- Add `PAGER=cat` to all psql invocations (prevents pager hangs in CI)
- Add dedicated i3 regression test that verifies FK detection works with intarray present

### Testing
- Tested locally on PostgreSQL 17 with intarray installed
- All 27 queries pass (s1/s2 expected to fail without shared_preload_libraries)

Supersedes #72
Fixes #62