### PR TITLE
feat(t2): add storage parameters (reloptions) query

### DIFF
--- a/sql/t2_storage_parameters.sql
+++ b/sql/t2_storage_parameters.sql
@@ -1,0 +1,58 @@
+-- Objects with custom storage parameters
+
+with rel_with_options as (
+  select
+    n.nspname as schema_name,
+    c.relname as object_name,
+    case c.relkind
+      when 'r' then 'table'
+      when 'i' then 'index'
+      when 'm' then 'materialized view'
+      when 'p' then 'partitioned table'
+      when 'I' then 'partitioned index'
+    end as object_type,
+    pg_size_pretty(pg_relation_size(c.oid)) as size,
+    pg_relation_size(c.oid) as size_bytes,
+    c.reloptions,
+    unnest(c.reloptions) as option,
+    c.relispartition,
+    (select n2.nspname || '.' || c2.relname
+     from pg_inherits as inh
+     join pg_class as c2 on inh.inhparent = c2.oid
+     join pg_namespace as n2 on c2.relnamespace = n2.oid
+     where inh.inhrelid = c.oid
+    ) as parent_table
+  from pg_class as c
+  join pg_namespace as n on c.relnamespace = n.oid
+  where c.reloptions is not null
+    and n.nspname not in ('pg_catalog', 'information_schema')
+    and c.relname != 'pg_stats'
+)
+select
+  schema_name,
+  object_name,
+  object_type,
+  case
+    when relispartition then 'partition of ' || parent_table
+    else null
+  end as partition_info,
+  size,
+  option,
+  case
+    when option ~ 'autovacuum_enabled=(false|off)' and size_bytes > 10485760
+      then 'WARNING: autovacuum disabled on table > 10 MiB'
+    when option ~ 'autovacuum_enabled=(false|off)'
+      then 'autovacuum disabled'
+    when option ~ 'fillfactor=([1-4][0-9])$'
+      then 'low fillfactor (< 50%)'
+    when option ~ 'autovacuum_vacuum_scale_factor=0\.0*[1-9]'
+      then 'aggressive autovacuum (low scale factor)'
+    else null
+  end as note
+from rel_with_options
+order by
+  parent_table nulls first,
+  size_bytes desc,
+  object_type,
+  schema_name,
+  object_name;

--- a/start.psql
+++ b/start.psql
@@ -25,6 +25,7 @@
 \echo '  s1 – Slowest queries, by total time (requires pg_stat_statements)'
 \echo '  s2 – Slowest queries report (requires pg_stat_statements)'
 \echo '  t1 – Postgres parameters tuning'
+\echo '  t2 – Objects with custom storage parameters'
 \echo '  v1 – Vacuum: current activity'
 \echo '  v2 – VACUUM progress and autovacuum queue'
 \echo '   q – Quit'
@@ -58,6 +59,7 @@ select
 :d_stp::text = 's1' as d_step_is_s1,
 :d_stp::text = 's2' as d_step_is_s2,
 :d_stp::text = 't1' as d_step_is_t1,
+:d_stp::text = 't2' as d_step_is_t2,
 :d_stp::text = 'v1' as d_step_is_v1,
 :d_stp::text = 'v2' as d_step_is_v2,
 :d_stp::text = 'q' as d_step_is_q \gset
@@ -162,6 +164,10 @@ select
   \ir ./start.psql
 \elif :d_step_is_t1
   \ir ./sql/t1_tuning.sql
+  \prompt 'Press <Enter> to continue…' d_dummy
+  \ir ./start.psql
+\elif :d_step_is_t2
+  \ir ./sql/t2_storage_parameters.sql
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_v1


### PR DESCRIPTION
## Summary

Rebased version of #73 — adds new t2 query to audit objects with custom storage parameters.

### What it shows
- All tables, indexes, materialized views with non-default `reloptions`
- Object type, size, individual storage parameter settings
- Partition relationships (shows parent table)
- Warnings for potentially problematic settings:
  - ⚠️ Autovacuum disabled on tables > 10 MiB
  - Low fillfactor (< 50%)
  - Aggressive autovacuum (very low scale factor)

### Changes from original #73
- Fixed: header comment missing space after `--`
- Fixed: fillfactor regex matched 50 but note said "< 50%" — now correctly matches only 10-49
- Fixed: `schema` alias renamed to `schema_name` (avoid reserved word)
- Fixed: added `as` for table aliases per SQL style guide
- Fixed: missing newline at EOF
- Fixed: **start.psql no longer silently drops c1** (original PR was branched before c1 existed)

### Testing
- Tested locally on PostgreSQL 17
- Verified fillfactor boundary: 49 → warning, 50 → no warning, 51 → no warning

Supersedes #73
Closes #61