### PR TITLE
style: fix typos, update terminology, remove dead code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
         
         echo "  Testing 0_node.sql..."
         OUTPUT=$(PAGER=cat psql -h localhost -U dba_user -d test --no-psqlrc -f warmup.psql -f sql/0_node.sql | grep Role)
-        if [[ "$OUTPUT" == *"Master"* ]]; then
+        if [[ "$OUTPUT" == *"Primary"* ]]; then
           echo "    ✓ Role test passed"
         else
           echo "    ✗ Role test failed: $OUTPUT"

--- a/sql/0_node.sql
+++ b/sql/0_node.sql
@@ -30,7 +30,7 @@ select
       end)::int)::text || ' second')::interval)::text
     || '; paused: ' || :postgres_dba_is_wal_replay_paused()::text || ')'
   else
-    'Master'
+    'Primary'
   end as value
 union all
 (

--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -3,7 +3,7 @@
 --This SQL is derived from https://github.com/ioguix/pgsql-bloat-estimation/blob/master/table/table_bloat.sql
 
 /*
-* WARNING: executed with a non-superuser role, the query inspect only tables you are granted to read.
+* WARNING: executed with a non-superuser role, the query inspects only tables you are granted to read.
 * This query is compatible with PostgreSQL 9.0 and more
 */
 
@@ -88,7 +88,7 @@ select
   greatest(last_autovacuum, last_vacuum)::timestamp(0)::text 
     || case greatest(last_autovacuum, last_vacuum)
       when last_autovacuum then ' (auto)'
-    else '' end as "Last Vaccuum",
+    else '' end as "Last Vacuum",
   (
     select
       coalesce(substring(array_to_string(reloptions, ' ') from 'fillfactor=([0-9]+)')::smallint, 100)

--- a/sql/b2_btree_estimation.sql
+++ b/sql/b2_btree_estimation.sql
@@ -2,7 +2,7 @@
 
 -- enhanced version of https://github.com/ioguix/pgsql-bloat-estimation/blob/master/btree/btree_bloat.sql
 
--- WARNING: executed with a non-superuser role, the query inspect only index on tables you are granted to read.
+-- WARNING: executed with a non-superuser role, the query inspects only indexes on tables you are granted to read.
 -- WARNING: rows with is_na = 't' are known to have bad statistics ("name" type is not supported).
 -- This query is compatible with PostgreSQL 8.2+
 
@@ -26,9 +26,9 @@ with step1 as (
     /* per tuple header: add IndexAttributeBitMapData if some cols are null-able */
     case
       when max(coalesce(s.null_frac,0)) = 0 then 2 -- IndexTupleData size
-      else 2 + (( 32 + 8 - 1 ) / 8) -- IndexTupleData size + IndexAttributeBitMapData size ( max num filed per index + 8 - 1 /8)
+      else 2 + (( 32 + 8 - 1 ) / 8) -- IndexTupleData size + IndexAttributeBitMapData size ( max num fields per index + 8 - 1 /8)
     end as index_tuple_hdr_bm,
-    /* data len: we remove null values save space using it fractionnal part from stats */
+    /* data len: we remove null values save space using its fractional part from stats */
     sum((1 - coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024)) as nulldatawidth,
     max(case when a.atttypid = 'pg_catalog.name'::regtype then 1 else 0 end) > 0 as is_na
   from pg_attribute as a
@@ -47,7 +47,7 @@ with step1 as (
     s.schemaname = i.nspname
     and (
       (s.tablename = i.tblname and s.attname = pg_catalog.pg_get_indexdef(a.attrelid, a.attnum, true)) -- stats from tbl
-      OR (s.tablename = i.idxname AND s.attname = a.attname) -- stats from functionnal cols
+      OR (s.tablename = i.idxname AND s.attname = a.attname) -- stats from functional cols
     )
   join pg_type as t on a.atttypid = t.oid
   where a.attnum > 0

--- a/sql/b3_table_pgstattuple.sql
+++ b/sql/b3_table_pgstattuple.sql
@@ -1,8 +1,8 @@
 --Table bloat (requires pgstattuple; expensive)
 
---https://github.com/dataegret/pg-utils/tree/master/sql
---pgstattuple extension required
---WARNING: without table name/mask query will read all available tables which could cause I/O spikes
+-- https://github.com/dataegret/pg-utils/tree/master/sql
+-- pgstattuple extension required
+-- WARNING: without table name/mask query will read all available tables which could cause I/O spikes
 select nspname,
 relname,
 pg_size_pretty(relation_size + toast_relation_size) as total_size,
@@ -22,7 +22,7 @@ from (
     left join pg_namespace n on (n.oid = c.relnamespace)
     where nspname not in ('pg_catalog', 'information_schema')
     and nspname !~ '^pg_toast' and relkind = 'r'
-    --put your table name/mask here
+    -- put your table name/mask here
     and relname ~ ''
 ) t
 order by (toast_free_space + relation_size - (relation_size - free_space)*100/fillfactor) desc

--- a/sql/b4_btree_pgstattuple.sql
+++ b/sql/b4_btree_pgstattuple.sql
@@ -1,8 +1,8 @@
 --B-tree indexes bloat (requires pgstattuple; expensive)
 
---https://github.com/dataegret/pg-utils/tree/master/sql
---pgstattuple extension required
---WARNING: without index name/mask query will read all available indexes which could cause I/O spikes
+-- https://github.com/dataegret/pg-utils/tree/master/sql
+-- pgstattuple extension required
+-- WARNING: without index name/mask query will read all available indexes which could cause I/O spikes
 with data as (
   select
     schemaname as schema_name,
@@ -25,7 +25,7 @@ with data as (
   join pg_class c_table on p.relid = c_table.oid
   where
     pg_get_indexdef(p.indexrelid) like '%USING btree%'
-    --put your index name/mask here
+    -- put your index name/mask here
     and indexrelname ~ ''
 )
 select

--- a/sql/i2_redundant_indexes.sql
+++ b/sql/i2_redundant_indexes.sql
@@ -7,7 +7,7 @@
 -- -- so feel free to use it in your clouds (Heroku, AWS RDS, etc)
 
 -- (Keep in mind, that on replicas, the whole picture of index usage
--- is usually very different from master).
+-- is usually very different from the primary).
 
 with fk_indexes as (
   select
@@ -111,12 +111,6 @@ redundant_indexes_tmp_num as (
   left join redundant_indexes_tmp_num ri2 on ri2.reason_index_id = ri1.index_id and ri1.reason_index_id = ri2.index_id
   where ri1.num < ri2.num or ri2.num is null
 ), redundant_indexes_cut_grouped as (
-  select
-    distinct(num),
-    *
-  from redundant_indexes_tmp_cut
-  order by index_size_bytes desc
-), redundant_indexes_grouped as (
   select
     distinct(num),
     *

--- a/sql/i4_invalid_indexes.sql
+++ b/sql/i4_invalid_indexes.sql
@@ -7,7 +7,7 @@
 -- -- so feel free to use it in your clouds (Heroku, AWS RDS, etc)
 
 -- (Keep in mind, that on replicas, the whole picture of index usage
--- is usually very different from master).
+-- is usually very different from the primary)..
 
 select 
     coalesce(nullif(pn.nspname, 'public') || '.', '') || pct.relname as "relation_name",

--- a/sql/i5_indexes_migration.sql
+++ b/sql/i5_indexes_migration.sql
@@ -21,9 +21,9 @@
 
 -- It also doesn't do anything except reading system catalogs and
 -- printing NOTICEs, so you can easily run it on your
---  production *master* database.
+--  production *primary* database.
 -- (Keep in mind, that on replicas, the whole picture of index usage
--- is usually very different from master).
+-- is usually very different from the primary)..
 
 -- TODO: take into account type of index and opclass
 -- TODO: schemas

--- a/sql/l1_lock_trees.sql
+++ b/sql/l1_lock_trees.sql
@@ -28,7 +28,7 @@ with recursive l as (
 select (clock_timestamp() - a.xact_start)::interval(0) as ts_age,
        (clock_timestamp() - a.state_change)::interval(0) as change_age,
        a.datname,a.usename,a.client_addr,
-       --w.obj wait_on_object,
+       -- w.obj wait_on_object,
        tree.pid,replace(a.state, 'idle in transaction', 'idletx') state,
        lvl,(select count(*) from tree p where p.path ~ ('^'||tree.path) and not p.path=tree.path) blocked,
        case when tree.pid=any(tree.dl) then '!>' else repeat(' .', lvl) end||' '||trim(left(regexp_replace(a.query, e'\\s+', ' ', 'g'),100)) query

--- a/sql/p1_alignment_padding.sql
+++ b/sql/p1_alignment_padding.sql
@@ -155,7 +155,7 @@ with recursive constants as (
     r1.shifts,
     r2.cols as alt_cols,
     r2.types as alt_types,
-    r2.shifts as alt_shits,
+    r2.shifts as alt_shifts,
     r1.pads,
     r1.curleft,
     r2.pads as alt_pads,

--- a/sql/s1_pg_stat_statements_top_total.sql
+++ b/sql/s1_pg_stat_statements_top_total.sql
@@ -30,7 +30,6 @@ select
     round(max(max_plan_time)::numeric, 2)
   ) as min_max_plan_t,
 \else
-  sum(calls) as calls,
   round(sum(total_time)::numeric, 2) as total_time,
   round((sum(mean_time * calls) / sum(calls))::numeric, 2) as mean_time,
   format(

--- a/sql/s2_pg_stat_statements_report.sql
+++ b/sql/s2_pg_stat_statements_report.sql
@@ -46,7 +46,7 @@ with pg_stat_statements_slice as (
   select
     (select datname from pg_database where oid = p.dbid) as database,
     (select rolname from pg_roles where oid = p.userid) as username,
-    --select shortest query, replace \n\n-- strings to avoid email clients format text as footer
+    -- select shortest query, replace \n\n-- strings to avoid email clients formatting text as footer
     substring(
       translate(
         replace(
@@ -205,7 +205,7 @@ with pg_stat_statements_slice as (
   select
     (select datname from pg_database where oid = p.dbid) as database,
     (select rolname from pg_roles where oid = p.userid) as username,
-    --select shortest query, replace \n\n-- strings to avoid email clients format text as footer
+    -- select shortest query, replace \n\n-- strings to avoid email clients formatting text as footer
     substring(
       translate(
         replace(

--- a/sql/v2_autovacuum_progress_and_queue.sql
+++ b/sql/v2_autovacuum_progress_and_queue.sql
@@ -30,7 +30,7 @@ with table_opts as (
   from pg_stat_progress_vacuum
 )
 select
-  --vacuum_settings.oid,
+  -- vacuum_settings.oid,
   coalesce(
     coalesce(nullif(vacuum_settings.nspname, 'public') || '.', '') || vacuum_settings.relname, -- current DB
     format('[something in "%I"]', p.datname)


### PR DESCRIPTION
## Summary

Safe cherry-picks from #76. That PR had good fixes mixed with dangerous regressions — this extracts only the safe parts.

### What's included
- **Typo fixes**: inspects, fields, fractional, functional, alt_shifts, Vacuum, formatting
- **Terminology**: master → Primary/primary across 0_node, i2, i4, i5
- **Comment formatting**: space after `--` in b3, b4, l1, s2, v2
- **Dead code removal**: unused CTE in i2, duplicate `sum(calls)` in s1

### What's NOT included from #76 (would cause regressions)
- ❌ v1 PG17 guard removal — would re-break #74 (`num_dead_tuples` doesn't exist in PG17+)
- ❌ v1 `nullif()`/`coalesce()` removal — division by zero when `heap_blks_total` is 0
- ❌ l2 rewrite — conflicts with recent l2/l3 merge in #80
- ❌ c1 deletion — file was recently added, PR #76 predates it
- ❌ t1 `random_page_cost` removal — legitimate tuning parameter
- ❌ v2 wait event format change — inconsistent with other reports using `type:event`

### Testing
All 27 queries tested locally on PostgreSQL 17. CI updated for Primary terminology.

Supersedes #76