### PR TITLE
feat(b6): add buffer cache contents report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements;' || echo "Warning: pg_stat_statements not available"
         psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pgstattuple;'
         psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS intarray;'
+        psql -h localhost -U postgres -d test -c 'CREATE EXTENSION IF NOT EXISTS pg_buffercache;'
         
         # Minimal privilege user
         psql -h localhost -U postgres -d test -c "CREATE USER dba_user;"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Then connect to any Postgres server via psql and type `:dba` to open the interac
 | b3 | Table bloat via `pgstattuple` (expensive) |
 | b4 | B-tree index bloat via `pgstattuple` (expensive) |
 | b5 | Tables and columns without stats (bloat cannot be estimated) |
+| b6 | Buffer cache contents (requires `pg_buffercache`, expensive) |
 
 ### Indexes
 | ID | Report |
@@ -69,6 +70,7 @@ Then connect to any Postgres server via psql and type `:dba` to open the interac
 | ID | Report |
 |----|--------|
 | t1 | Postgres parameters tuning |
+| t2 | Objects with custom storage parameters |
 | e1 | Installed extensions |
 | p1 | Alignment padding analysis (experimental) |
 | r1 | Create user with random password (interactive) |

--- a/sql/b6_buffercache.sql
+++ b/sql/b6_buffercache.sql
@@ -1,0 +1,49 @@
+-- Buffer cache contents (requires pg_buffercache; expensive on large shared_buffers)
+
+with buf as (
+  select
+    c.oid as relid,
+    n.nspname as schema_name,
+    c.relname,
+    case c.relkind
+      when 'r' then 'table'
+      when 'i' then 'index'
+      when 't' then 'TOAST table'
+      when 'm' then 'materialized view'
+      when 'S' then 'sequence'
+      else c.relkind::text
+    end as object_type,
+    count(*) as buffers,
+    count(*) filter (where b.isdirty) as dirty_buffers,
+    round(
+      100.0 * count(*) / (
+        select count(*) from pg_buffercache where relfilenode is not null
+      ),
+      1
+    ) as pct_of_cache,
+    round(
+      100.0 * count(*) / greatest(pg_relation_size(c.oid) / current_setting('block_size')::int, 1),
+      1
+    ) as pct_of_rel,
+    pg_size_pretty(count(*) * current_setting('block_size')::int) as cached_size,
+    pg_size_pretty(pg_relation_size(c.oid)) as rel_size
+  from pg_buffercache as b
+  join pg_class as c on b.relfilenode = pg_relation_filenode(c.oid)
+  join pg_namespace as n on c.relnamespace = n.oid
+  where b.relfilenode is not null
+    and n.nspname not in ('pg_catalog', 'information_schema')
+    and n.nspname !~ '^pg_toast'
+  group by c.oid, n.nspname, c.relname, c.relkind
+)
+select
+  coalesce(nullif(schema_name, 'public') || '.', '') || relname as "Object",
+  object_type as "Type",
+  rel_size as "Size",
+  cached_size as "Cached",
+  pct_of_rel || '%' as "% of Rel",
+  pct_of_cache || '%' as "% of Cache",
+  buffers as "Buffers",
+  dirty_buffers as "Dirty"
+from buf
+order by buffers desc
+limit 50;

--- a/start.psql
+++ b/start.psql
@@ -10,6 +10,7 @@
 \echo '  b3 – Table bloat (requires pgstattuple; expensive)'
 \echo '  b4 – B-tree indexes bloat (requires pgstattuple; expensive)'
 \echo '  b5 – Tables and columns without stats (so bloat cannot be estimated)'
+\echo '  b6 – Buffer cache contents (requires pg_buffercache; expensive)'
 \echo '  c1 – Index (re)creation progress (CREATE INDEX / REINDEX)'
 \echo '  e1 – Extensions installed in current database'
 \echo '  i1 – Unused and rarely used indexes'
@@ -44,6 +45,7 @@ select
 :d_stp::text = 'b3' as d_step_is_b3,
 :d_stp::text = 'b4' as d_step_is_b4,
 :d_stp::text = 'b5' as d_step_is_b5,
+:d_stp::text = 'b6' as d_step_is_b6,
 :d_stp::text = 'c1' as d_step_is_c1,
 :d_stp::text = 'e1' as d_step_is_e1,
 :d_stp::text = 'i1' as d_step_is_i1,
@@ -104,6 +106,10 @@ select
   \ir ./start.psql
 \elif :d_step_is_b5
   \ir ./sql/b5_tables_no_stats.sql
+  \prompt 'Press <Enter> to continue…' d_dummy
+  \ir ./start.psql
+\elif :d_step_is_b6
+  \ir ./sql/b6_buffercache.sql
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_c1


### PR DESCRIPTION
## Summary

New b6 report: what's currently in `shared_buffers`.

### Output columns
| Column | Description |
|---|---|
| Object | Schema-qualified relation name |
| Type | table, index, TOAST table, materialized view |
| Size | On-disk relation size |
| Cached | Size currently in buffer cache |
| % of Rel | How much of the relation is cached |
| % of Cache | How much of total cache this relation uses |
| Buffers | Number of buffers |
| Dirty | Number of dirty (unwritten) buffers |

### Example
```
     Object     | Type  |   Size   |  Cached  | % of Rel | % of Cache | Buffers | Dirty
----------------+-------+----------+----------+----------+------------+---------+-------
 relopts_test2  | table | 17 MB    | 17 MB    | 100.1%   | 27.7%      |    2216 |     0
 fk_child       | table | 10192 kB | 10224 kB | 100.3%   | 15.9%      |    1278 |     0
```

### Details
- Requires `pg_buffercache` extension (like b3/b4 require pgstattuple)
- Filters out system catalogs and TOAST tables
- Top 50 by buffer count
- Also adds t2 and b6 to README

### Testing
- Tested on PG17 as superuser and pg_monitor user
- pg_buffercache added to CI extensions

Closes #28