### PR TITLE
feat(s3): add workload profile by query type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Then connect to any Postgres server via psql and type `:dba` to open the interac
 |----|--------|
 | s1 | Slowest queries by total time (requires `pg_stat_statements`) |
 | s2 | Slowest queries report (requires `pg_stat_statements`) |
+| s3 | Workload profile by query type (requires `pg_stat_statements`) |
 
 ### Configuration and other
 | ID | Report |

--- a/sql/s3_pg_stat_statements_workload.sql
+++ b/sql/s3_pg_stat_statements_workload.sql
@@ -1,0 +1,73 @@
+-- Workload profile by query type (requires pg_stat_statements)
+
+-- Groups pg_stat_statements entries by first SQL keyword.
+-- Strips block comments (/* ... */) and line comments (-- ...)
+-- before extracting the keyword.
+
+\if :postgres_dba_pgvers_13plus
+with data as (
+  select
+    lower((regexp_match(
+      regexp_replace(
+        regexp_replace(query, '/\*.*?\*/', '', 'gs'),
+        '^\s*(--[^\n]*\n\s*)*', '', 'g'
+      ),
+      '^\s*(\w+)'
+    ))[1]) as word,
+    calls,
+    total_exec_time,
+    total_plan_time,
+    rows
+  from pg_stat_statements
+)
+select
+  coalesce(word, '???') as "Query Type",
+  sum(calls) as "Calls",
+  round(
+    100.0 * sum(calls) / nullif(sum(sum(calls)) over (), 0), 1
+  ) as "Calls %",
+  round(sum(total_exec_time)::numeric, 1) as "Exec (ms)",
+  round(
+    100.0 * sum(total_exec_time) / nullif(sum(sum(total_exec_time)) over (), 0), 1
+  ) as "Exec %",
+  round(sum(total_plan_time)::numeric, 1) as "Plan (ms)",
+  round(
+    (sum(total_exec_time) / nullif(sum(calls), 0))::numeric, 3
+  ) as "Avg (ms/call)",
+  sum(rows) as "Rows"
+from data
+group by word
+order by sum(total_exec_time) desc;
+\else
+with data as (
+  select
+    lower((regexp_match(
+      regexp_replace(
+        regexp_replace(query, '/\*.*?\*/', '', 'gs'),
+        '^\s*(--[^\n]*\n\s*)*', '', 'g'
+      ),
+      '^\s*(\w+)'
+    ))[1]) as word,
+    calls,
+    total_time,
+    rows
+  from pg_stat_statements
+)
+select
+  coalesce(word, '???') as "Query Type",
+  sum(calls) as "Calls",
+  round(
+    100.0 * sum(calls) / nullif(sum(sum(calls)) over (), 0), 1
+  ) as "Calls %",
+  round(sum(total_time)::numeric, 1) as "Time (ms)",
+  round(
+    100.0 * sum(total_time) / nullif(sum(sum(total_time)) over (), 0), 1
+  ) as "Time %",
+  round(
+    (sum(total_time) / nullif(sum(calls), 0))::numeric, 3
+  ) as "Avg (ms/call)",
+  sum(rows) as "Rows"
+from data
+group by word
+order by sum(total_time) desc;
+\endif

--- a/start.psql
+++ b/start.psql
@@ -24,6 +24,7 @@
 \echo '  r2 – Alter user with random password (interactive)'
 \echo '  s1 – Slowest queries, by total time (requires pg_stat_statements)'
 \echo '  s2 – Slowest queries report (requires pg_stat_statements)'
+\echo '  s3 – Workload profile by query type (requires pg_stat_statements)'
 \echo '  t1 – Postgres parameters tuning'
 \echo '  t2 – Objects with custom storage parameters'
 \echo '  v1 – Vacuum: current activity'
@@ -58,6 +59,7 @@ select
 :d_stp::text = 'r2' as d_step_is_r2,
 :d_stp::text = 's1' as d_step_is_s1,
 :d_stp::text = 's2' as d_step_is_s2,
+:d_stp::text = 's3' as d_step_is_s3,
 :d_stp::text = 't1' as d_step_is_t1,
 :d_stp::text = 't2' as d_step_is_t2,
 :d_stp::text = 'v1' as d_step_is_v1,
@@ -160,6 +162,10 @@ select
   \ir ./start.psql
 \elif :d_step_is_s2
   \ir ./sql/s2_pg_stat_statements_report.sql
+  \prompt 'Press <Enter> to continue…' d_dummy
+  \ir ./start.psql
+\elif :d_step_is_s3
+  \ir ./sql/s3_pg_stat_statements_workload.sql
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_t1


### PR DESCRIPTION
## Summary

New s3 report: workload composition from pg_stat_statements, grouped by first SQL keyword.

### The comment problem (#37)
Simple `regexp_replace(query, '^\W*(\w+)...')` breaks on queries like:
```sql
/* pgbouncer health check */ SELECT 1
-- application: myapp
INSERT INTO events ...
```

The fix strips comments before extracting:
1. Remove block comments: `/\*.*?\*/` (with `gs` flags for multi-line)
2. Remove leading line comments: `^\s*(--[^\n]*\n\s*)*`
3. Extract first word: `^\s*(\w+)`

### Tested regex against
| Input | Extracted |
|---|---|
| `SELECT 1` | select |
| `/* comment */ SELECT 1` | select |
| `/* multi\nline */ INSERT ...` | insert |
| `-- comment\nSELECT 1` | select |
| `-- c1\n-- c2\nUPDATE ...` | update |
| `/* c1 */ -- c2\nDELETE ...` | delete |

### Output columns (PG13+)
| Column | Description |
|---|---|
| Query Type | First SQL keyword (select, insert, update, etc.) |
| Calls | Total call count |
| Calls % | Percentage of all calls |
| Exec (ms) | Total execution time |
| Exec % | Percentage of total exec time |
| Plan (ms) | Total planning time |
| Avg (ms/call) | Average execution time per call |
| Rows | Total rows affected |

Closes #37