### PR TITLE
fix(b6): correct buffer attribution and pct_of_rel calculation

### DIFF
--- a/sql/b6_buffercache.sql
+++ b/sql/b6_buffercache.sql
@@ -17,20 +17,31 @@ with buf as (
     count(*) filter (where b.isdirty) as dirty_buffers,
     round(
       100.0 * count(*) / (
-        select count(*) from pg_buffercache where relfilenode is not null
+        select count(*)
+        from pg_buffercache
+        where reldatabase = (select oid from pg_database where datname = current_database())
+          and relfilenode is not null
       ),
       1
     ) as pct_of_cache,
     round(
-      100.0 * count(*) / greatest(pg_relation_size(c.oid) / current_setting('block_size')::int, 1),
+      100.0 * count(*) / greatest(
+        ceil(pg_relation_size(c.oid)::numeric / current_setting('block_size')::numeric),
+        1
+      ),
       1
     ) as pct_of_rel,
     pg_size_pretty(count(*) * current_setting('block_size')::int) as cached_size,
     pg_size_pretty(pg_relation_size(c.oid)) as rel_size
   from pg_buffercache as b
-  join pg_class as c on b.relfilenode = pg_relation_filenode(c.oid)
+  join pg_class as c
+    on c.oid = (
+      select pg_filenode_relation(b.reltablespace, b.relfilenode)
+    )
   join pg_namespace as n on c.relnamespace = n.oid
-  where b.relfilenode is not null
+  where b.reldatabase = (select oid from pg_database where datname = current_database())
+    and b.relfilenode is not null
+    and b.relforknumber = 0
     and n.nspname not in ('pg_catalog', 'information_schema')
     and n.nspname !~ '^pg_toast'
   group by c.oid, n.nspname, c.relname, c.relkind


### PR DESCRIPTION
Addresses review feedback from Tembo on #85.

### Fixes
1. **Filenode collision**: `relfilenode` isn't globally unique across databases. Now filters by `reldatabase = current_database()` and uses `pg_filenode_relation()` for accurate OID resolution.

2. **relforknumber filter**: Only count main fork buffers (`relforknumber = 0`) to match `pg_relation_size()` which also returns main fork size.

3. **pct_of_rel >100%**: Integer division in `pg_relation_size() / block_size` truncated, causing percentages like 100.3%. Using `ceil()` on numeric division fixes this.

### Before/After
```
-- Before: 100.1%, 100.3%, 100.7% (integer division artifacts)
-- After:  100.0% for fully cached relations
```

### Testing
Tested on PG17 with pg_buffercache + shared_preload_libraries.