### PR TITLE
Rework amcheck: 3 reports (c1/c2/c3), include system indexes, add GIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Then connect to any Postgres server via psql and type `:dba` to open the interac
 ### Corruption checks
 | ID | Report |
 |----|--------|
-| c1 | B-tree index integrity check (amcheck, non-blocking) |
-| c2 | Full B-tree + heap integrity check (amcheck, takes locks — use on standby!) |
+| c1 | Quick: btree + GIN (PG18) + heap (PG14) check — safe for production (AccessShareLock) |
+| c2 | Parent: btree parent-child check — detects glibc/collation corruption (⚠️ ShareLock) |
+| c3 | Full: heapallindexed + parent + heap — proves every tuple is indexed (⚠️⚠️ slow + ShareLock) |
 
 ### Memory
 | ID | Report |

--- a/sql/c1_amcheck_quick.sql
+++ b/sql/c1_amcheck_quick.sql
@@ -1,9 +1,9 @@
--- Corruption: B-tree index integrity check (amcheck, non-blocking)
+-- Corruption: quick check — btree, GIN (PG18+), heap (PG14+). Safe for production.
 -- Requires: CREATE EXTENSION amcheck
--- Uses bt_index_check() — lightweight, safe for production primaries.
--- Does NOT lock tables (only AccessShareLock on indexes).
--- Checks internal page consistency of all btree indexes.
--- On PG14+, also runs verify_heapam() to detect heap corruption.
+-- All checks use AccessShareLock only (same as SELECT) — no write blocking.
+-- Checks page-level consistency of btree indexes (bt_index_check).
+-- On PG18+, also checks GIN indexes (gin_index_check).
+-- On PG14+, also checks heap and TOAST integrity (verify_heapam).
 
 do $$
 declare
@@ -12,6 +12,9 @@ declare
   idx_count int := 0;
   err_count int := 0;
   skip_count int := 0;
+  gin_count int := 0;
+  gin_err_count int := 0;
+  gin_skip_count int := 0;
   tbl_count int := 0;
   tbl_err_count int := 0;
   tbl_skip_count int := 0;
@@ -26,9 +29,9 @@ begin
 
   select current_setting('server_version_num')::int into pg_version;
 
+  -- === B-tree indexes ===
   raise notice '';
-  raise notice '=== B-tree index integrity (bt_index_check) ===';
-  raise notice 'Checking all btree indexes in the current database...';
+  raise notice '=== B-tree index check (bt_index_check, AccessShareLock) ===';
   raise notice '';
 
   for rec in
@@ -43,8 +46,6 @@ begin
     join pg_namespace n on n.oid = c.relnamespace
     join pg_am a on a.oid = c.relam
     where a.amname = 'btree'
-      and n.nspname not in ('pg_catalog', 'information_schema')
-      and n.nspname !~ '^pg_toast'
       and c.relpersistence != 't'
       and i.indisvalid
     order by n.nspname, t.relname, c.relname
@@ -54,30 +55,75 @@ begin
       idx_count := idx_count + 1;
     exception
       when insufficient_privilege then
-        raise notice '⚠️  Permission denied for %.% — need superuser or amcheck privileges', rec.schema_name, rec.index_name;
         skip_count := skip_count + 1;
       when others then
-        raise warning '❌ CORRUPTION in %.% (table %.%): %',
-          rec.schema_name, rec.index_name,
-          rec.schema_name, rec.table_name,
-          sqlerrm;
+        raise warning '❌ CORRUPTION in %.%: %',
+          rec.schema_name, rec.index_name, sqlerrm;
         err_count := err_count + 1;
     end;
   end loop;
 
   if err_count = 0 and skip_count = 0 then
-    raise notice '✅ All % btree indexes passed integrity check.', idx_count;
+    raise notice '✅ All % btree indexes OK.', idx_count;
   elsif err_count = 0 then
-    raise notice '✅ % btree indexes passed, % skipped (insufficient privileges).', idx_count, skip_count;
+    raise notice '✅ % btree indexes OK, % skipped (insufficient privileges).', idx_count, skip_count;
   else
     raise warning '❌ % of % btree indexes have corruption!', err_count, idx_count + err_count + skip_count;
   end if;
 
-  -- Heap verification (PG14+ only)
+  -- === GIN indexes (PG18+) ===
+  if pg_version >= 180000 then
+    raise notice '';
+    raise notice '=== GIN index check (gin_index_check, AccessShareLock) ===';
+    raise notice '';
+
+    for rec in
+      select
+        n.nspname as schema_name,
+        c.relname as index_name,
+        t.relname as table_name,
+        c.oid as index_oid
+      from pg_index i
+      join pg_class c on c.oid = i.indexrelid
+      join pg_class t on t.oid = i.indrelid
+      join pg_namespace n on n.oid = c.relnamespace
+      join pg_am a on a.oid = c.relam
+      where a.amname = 'gin'
+        and c.relpersistence != 't'
+        and i.indisvalid
+      order by n.nspname, t.relname, c.relname
+    loop
+      begin
+        perform gin_index_check(rec.index_oid);
+        gin_count := gin_count + 1;
+      exception
+        when insufficient_privilege then
+          gin_skip_count := gin_skip_count + 1;
+        when others then
+          raise warning '❌ CORRUPTION in %.%: %',
+            rec.schema_name, rec.index_name, sqlerrm;
+          gin_err_count := gin_err_count + 1;
+      end;
+    end loop;
+
+    if gin_count + gin_err_count + gin_skip_count = 0 then
+      raise notice 'No GIN indexes found.';
+    elsif gin_err_count = 0 and gin_skip_count = 0 then
+      raise notice '✅ All % GIN indexes OK.', gin_count;
+    elsif gin_err_count = 0 then
+      raise notice '✅ % GIN indexes OK, % skipped (insufficient privileges).', gin_count, gin_skip_count;
+    else
+      raise warning '❌ % of % GIN indexes have corruption!', gin_err_count, gin_count + gin_err_count + gin_skip_count;
+    end if;
+  else
+    raise notice '';
+    raise notice 'ℹ️  GIN index checking requires PostgreSQL 18+. Skipped.';
+  end if;
+
+  -- === Heap verification (PG14+) ===
   if pg_version >= 140000 then
     raise notice '';
-    raise notice '=== Heap integrity (verify_heapam) ===';
-    raise notice 'Checking all user tables for heap corruption...';
+    raise notice '=== Heap check (verify_heapam, AccessShareLock) ===';
     raise notice '';
 
     for rec in
@@ -88,7 +134,6 @@ begin
       from pg_class c
       join pg_namespace n on n.oid = c.relnamespace
       where c.relkind = 'r'
-        and n.nspname not in ('pg_catalog', 'information_schema')
         and c.relpersistence != 't'
       order by n.nspname, c.relname
     loop
@@ -107,7 +152,6 @@ begin
         end loop;
       exception
         when insufficient_privilege then
-          raise notice '⚠️  Permission denied for %.% — need superuser or amcheck privileges', rec.schema_name, rec.table_name;
           tbl_skip_count := tbl_skip_count + 1;
         when others then
           raise warning 'ERROR checking %.%: %', rec.schema_name, rec.table_name, sqlerrm;
@@ -117,9 +161,9 @@ begin
     end loop;
 
     if tbl_err_count = 0 and tbl_skip_count = 0 then
-      raise notice '✅ All % tables passed heap integrity check.', tbl_count;
+      raise notice '✅ All % tables passed heap check.', tbl_count;
     elsif tbl_err_count = 0 then
-      raise notice '✅ % tables passed, % skipped (insufficient privileges).', tbl_count - tbl_skip_count, tbl_skip_count;
+      raise notice '✅ % tables OK, % skipped (insufficient privileges).', tbl_count - tbl_skip_count, tbl_skip_count;
     else
       raise warning '❌ % of % tables have corruption!', tbl_err_count, tbl_count;
     end if;

--- a/sql/c2_amcheck_parent.sql
+++ b/sql/c2_amcheck_parent.sql
@@ -1,0 +1,92 @@
+-- Corruption: B-tree parent check — detects collation/glibc corruption. ⚠️ ShareLock!
+-- Requires: CREATE EXTENSION amcheck
+-- ⚠️  Takes ShareLock on each index — blocks writes while checking!
+-- ⚠️  Best used on STANDBYS or during maintenance windows.
+--
+-- Uses bt_index_parent_check() which verifies parent-child key ordering.
+-- This is the most reliable way to detect corruption caused by glibc/ICU
+-- version changes that silently alter collation sort order.
+-- Also checks sibling page pointers and descends from root (rootdescend).
+-- On PG14+, also verifies unique constraint consistency (checkunique).
+
+do $$
+declare
+  rec record;
+  idx_count int := 0;
+  err_count int := 0;
+  skip_count int := 0;
+  pg_version int;
+begin
+  -- Check extension
+  if not exists (select 1 from pg_extension where extname = 'amcheck') then
+    raise notice '❌ amcheck extension is not installed. Run: CREATE EXTENSION amcheck;';
+    return;
+  end if;
+
+  select current_setting('server_version_num')::int into pg_version;
+
+  raise warning '';
+  raise warning '⚠️  WARNING: This check takes ShareLock on each index — blocks writes!';
+  raise warning '⚠️  Recommended: run on a STANDBY or during a maintenance window.';
+  raise warning '';
+  raise notice '=== B-tree parent check (bt_index_parent_check, ShareLock) ===';
+  raise notice 'Detects: collation/glibc corruption, parent-child inconsistency, sibling pointer errors';
+  raise notice '';
+
+  for rec in
+    select
+      n.nspname as schema_name,
+      c.relname as index_name,
+      t.relname as table_name,
+      c.oid as index_oid,
+      pg_relation_size(c.oid) as index_size
+    from pg_index i
+    join pg_class c on c.oid = i.indexrelid
+    join pg_class t on t.oid = i.indrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_am a on a.oid = c.relam
+    where a.amname = 'btree'
+      and c.relpersistence != 't'
+      and i.indisvalid
+    order by pg_relation_size(c.oid) asc  -- smallest first
+  loop
+    begin
+      if pg_version >= 140000 then
+        perform bt_index_parent_check(
+          rec.index_oid,
+          heapallindexed := false,
+          rootdescend := true,
+          checkunique := true
+        );
+      elsif pg_version >= 110000 then
+        perform bt_index_parent_check(
+          rec.index_oid,
+          heapallindexed := false,
+          rootdescend := true
+        );
+      else
+        perform bt_index_parent_check(rec.index_oid);
+      end if;
+      idx_count := idx_count + 1;
+    exception
+      when insufficient_privilege then
+        skip_count := skip_count + 1;
+      when others then
+        raise warning '❌ CORRUPTION in %.% (table %.%, size %): %',
+          rec.schema_name, rec.index_name,
+          rec.schema_name, rec.table_name,
+          pg_size_pretty(rec.index_size),
+          sqlerrm;
+        err_count := err_count + 1;
+    end;
+  end loop;
+
+  if err_count = 0 and skip_count = 0 then
+    raise notice '✅ All % btree indexes passed parent check.', idx_count;
+  elsif err_count = 0 then
+    raise notice '✅ % btree indexes OK, % skipped (insufficient privileges).', idx_count, skip_count;
+  else
+    raise warning '❌ % of % btree indexes have corruption!', err_count, idx_count + err_count + skip_count;
+  end if;
+end;
+$$;

--- a/sql/c3_amcheck_full.sql
+++ b/sql/c3_amcheck_full.sql
@@ -1,10 +1,12 @@
--- Corruption: Full B-tree + heap check (amcheck, takes locks – use on standby!)
+-- Corruption: FULL check — heapallindexed + parent + heap. ⚠️⚠️ SLOW + ShareLock!
 -- Requires: CREATE EXTENSION amcheck
--- Uses bt_index_parent_check(heapallindexed := true) — thorough, takes locks.
--- ⚠️  Takes ShareLock on each index. Run on standbys or during maintenance windows.
--- Checks parent-child consistency, sibling pointers, root descent, unique constraints.
--- Verifies all heap tuples have corresponding index entries.
--- On PG14+, also runs verify_heapam() with full TOAST checking.
+-- ⚠️⚠️  HEAVY: Takes ShareLock AND scans entire heap for each index!
+-- ⚠️⚠️  This WILL be slow on large databases. Use on STANDBYS only.
+--
+-- bt_index_parent_check with heapallindexed=true: verifies that every single
+-- heap tuple has a corresponding index entry. Catches silent data loss where
+-- rows exist but are invisible to index scans.
+-- On PG14+: also verify_heapam with full TOAST checking.
 
 do $$
 declare
@@ -27,10 +29,15 @@ begin
 
   select current_setting('server_version_num')::int into pg_version;
 
-  raise warning '⚠️  This check takes locks! Use on standbys or during maintenance windows.';
-  raise notice '';
-  raise notice '=== Full B-tree index integrity (bt_index_parent_check + heapallindexed) ===';
-  raise notice 'Checking all btree indexes with parent-child + heap verification...';
+  raise warning '';
+  raise warning '⚠️⚠️  WARNING: This is the HEAVIEST corruption check!';
+  raise warning '⚠️⚠️  Takes ShareLock on each index (blocks writes) AND scans entire heap.';
+  raise warning '⚠️⚠️  On large databases this can take HOURS. Use on standbys only.';
+  raise warning '';
+
+  -- === Full B-tree check ===
+  raise notice '=== Full B-tree check (bt_index_parent_check + heapallindexed, ShareLock) ===';
+  raise notice 'Verifies: parent-child ordering, all heap tuples indexed, unique constraints';
   raise notice '';
 
   for rec in
@@ -46,8 +53,6 @@ begin
     join pg_namespace n on n.oid = c.relnamespace
     join pg_am a on a.oid = c.relam
     where a.amname = 'btree'
-      and n.nspname not in ('pg_catalog', 'information_schema')
-      and n.nspname !~ '^pg_toast'
       and c.relpersistence != 't'
       and i.indisvalid
     order by pg_relation_size(c.oid) asc  -- smallest first
@@ -72,7 +77,6 @@ begin
       idx_count := idx_count + 1;
     exception
       when insufficient_privilege then
-        raise notice '⚠️  Permission denied for %.% — need superuser or amcheck privileges', rec.schema_name, rec.index_name;
         skip_count := skip_count + 1;
       when others then
         raise warning '❌ CORRUPTION in %.% (table %.%, size %): %',
@@ -85,18 +89,17 @@ begin
   end loop;
 
   if err_count = 0 and skip_count = 0 then
-    raise notice '✅ All % btree indexes passed full integrity check.', idx_count;
+    raise notice '✅ All % btree indexes passed full check.', idx_count;
   elsif err_count = 0 then
-    raise notice '✅ % btree indexes passed, % skipped (insufficient privileges).', idx_count, skip_count;
+    raise notice '✅ % btree indexes OK, % skipped (insufficient privileges).', idx_count, skip_count;
   else
     raise warning '❌ % of % btree indexes have corruption!', err_count, idx_count + err_count + skip_count;
   end if;
 
-  -- Full heap verification (PG14+ only)
+  -- === Full heap verification (PG14+) ===
   if pg_version >= 140000 then
     raise notice '';
-    raise notice '=== Full heap integrity (verify_heapam + TOAST) ===';
-    raise notice 'Checking all user tables for heap and TOAST corruption...';
+    raise notice '=== Full heap check (verify_heapam + TOAST, AccessShareLock) ===';
     raise notice '';
 
     for rec in
@@ -108,7 +111,6 @@ begin
       from pg_class c
       join pg_namespace n on n.oid = c.relnamespace
       where c.relkind = 'r'
-        and n.nspname not in ('pg_catalog', 'information_schema')
         and c.relpersistence != 't'
       order by n.nspname, c.relname
     loop
@@ -132,7 +134,6 @@ begin
         end loop;
       exception
         when insufficient_privilege then
-          raise notice '⚠️  Permission denied for %.% — need superuser or amcheck privileges', rec.schema_name, rec.table_name;
           tbl_skip_count := tbl_skip_count + 1;
         when others then
           raise warning 'ERROR checking %.%: %', rec.schema_name, rec.table_name, sqlerrm;
@@ -142,9 +143,9 @@ begin
     end loop;
 
     if tbl_err_count = 0 and tbl_skip_count = 0 then
-      raise notice '✅ All % tables passed full heap integrity check.', tbl_count;
+      raise notice '✅ All % tables passed full heap check.', tbl_count;
     elsif tbl_err_count = 0 then
-      raise notice '✅ % tables passed, % skipped (insufficient privileges).', tbl_count - tbl_skip_count, tbl_skip_count;
+      raise notice '✅ % tables OK, % skipped (insufficient privileges).', tbl_count - tbl_skip_count, tbl_skip_count;
     else
       raise warning '❌ % of % tables have corruption!', tbl_err_count, tbl_count;
     end if;

--- a/start.psql
+++ b/start.psql
@@ -10,8 +10,9 @@
 \echo '  b3 – Table bloat (requires pgstattuple; expensive)'
 \echo '  b4 – B-tree indexes bloat (requires pgstattuple; expensive)'
 \echo '  b5 – Tables and columns without stats (so bloat cannot be estimated)'
-\echo '  c1 –  Corruption: B-tree index integrity check (amcheck, non-blocking)'
-\echo '  c2 –  Corruption: Full B-tree + heap check (amcheck, takes locks – use on standby!)'
+\echo '  c1 –  Corruption: quick check — btree, GIN (PG18+), heap (PG14+). Safe for production.'
+\echo '  c2 –  Corruption: B-tree parent check — detects collation/glibc corruption. ⚠️ ShareLock!'
+\echo '  c3 –  Corruption: FULL check — heapallindexed + parent + heap. ⚠️⚠️ SLOW + ShareLock!'
 \echo '  e1 – Extensions installed in current database'
 \echo '  i1 – Unused and rarely used indexes'
 \echo '  i2 – Redundant indexes'
@@ -50,6 +51,7 @@ select
 :d_stp::text = 'b5' as d_step_is_b5,
 :d_stp::text = 'c1' as d_step_is_c1,
 :d_stp::text = 'c2' as d_step_is_c2,
+:d_stp::text = 'c3' as d_step_is_c3,
 :d_stp::text = 'e1' as d_step_is_e1,
 :d_stp::text = 'i1' as d_step_is_i1,
 :d_stp::text = 'i2' as d_step_is_i2,
@@ -115,11 +117,15 @@ select
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_c1
-  \ir ./sql/c1_amcheck_btree.sql
+  \ir ./sql/c1_amcheck_quick.sql
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_c2
-  \ir ./sql/c2_amcheck_full.sql
+  \ir ./sql/c2_amcheck_parent.sql
+  \prompt 'Press <Enter> to continue…' d_dummy
+  \ir ./start.psql
+\elif :d_step_is_c3
+  \ir ./sql/c3_amcheck_full.sql
   \prompt 'Press <Enter> to continue…' d_dummy
   \ir ./start.psql
 \elif :d_step_is_e1


### PR DESCRIPTION
Follow-up to #89. Reworks the corruption checks based on feedback.

## Changes

### 3 reports instead of 2 — clearer separation by use case:

| Report | Lock | What it checks | When to use |
|--------|------|----------------|-------------|
| **c1** | AccessShareLock | btree pages, GIN (PG18+), heap+TOAST (PG14+) | Production primary — safe, fast |
| **c2** | **ShareLock** ⚠️ | btree parent-child ordering, sibling pointers, rootdescend, checkunique (PG14+) | **Standby** — detects glibc/collation corruption |
| **c3** | **ShareLock** ⚠️⚠️ | Everything in c2 + heapallindexed + verify_heapam with full TOAST | **Standby only** — proves every heap tuple is indexed, slowest |

### System indexes included
All three reports now check `pg_catalog` and `pg_toast` indexes too. System catalog corruption is arguably more critical than user table corruption.

### GIN support (PG18+)
c1 checks GIN indexes via `gin_index_check()` on PostgreSQL 18+.

### Big fat warnings
c2 and c3 emit prominent warnings about ShareLock blocking writes.

### Testing
- PG13: 158 btree indexes checked (no verify_heapam, no GIN)
- PG17: 168 btree indexes + 73 tables checked
- Superuser and non-superuser scenarios verified